### PR TITLE
Migrate Ducks

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ class Router extends React.Component {
             }
 
             dispatch({
-              type: actionMap[data.type || tabChild.props.type] || 'ROUTER_PUSH',
+              type: actionMap[data.type || tabChild.props.type] || actionTypes.ROUTER_PUSH,
               payload: { name: tabName, tabBarName, data }
             });
           };
@@ -120,7 +120,7 @@ class Router extends React.Component {
           }
 
           dispatch({
-            type: actionMap[data.type || child.props.type] || 'ROUTER_PUSH',
+            type: actionMap[data.type || child.props.type] || actionTypes.ROUTER_PUSH,
             payload: { name, data },
           });
         };

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,13 +1,11 @@
-import { createConstants } from './utils';
-
-export const actionTypes = createConstants(
-  'ROUTER_CHANGE_TAB',
-  'ROUTER_INIT',
-  'ROUTER_POP',
-  'ROUTER_PUSH',
-  'ROUTER_REPLACE',
-  'ROUTER_RESET',
-);
+export const actionTypes = {
+  'ROUTER_CHANGE_TAB': 'react-native-router-redux/ROUTER_CHANGE_TAB',
+  'ROUTER_INIT': 'react-native-router-redux/ROUTER_INIT',
+  'ROUTER_POP': 'react-native-router-redux/ROUTER_POP',
+  'ROUTER_PUSH': 'react-native-router-redux/ROUTER_PUSH',
+  'ROUTER_REPLACE': 'react-native-router-redux/ROUTER_REPLACE',
+  'ROUTER_RESET': 'react-native-router-redux/ROUTER_RESET'
+}
 
 const filter = data => {
   if (typeof(data) !== 'object') {

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -32,7 +32,7 @@ const findTabStack = (tabState, tabBar, tab) => {
   }
 };
 
-export default createReducer(initialState, {
+export default reducer = createReducer(initialState, {
   [actionTypes.ROUTER_CHANGE_TAB]: (state, { payload = {} }) => {
     const routeStacks = Object.assign({}, state.routeStacks);
     const currentRoutes = payload.navigator.getCurrentRoutes();

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,10 +1,3 @@
-export function createConstants(...constants) {
-  return constants.reduce((acc, constant) => {
-    acc[constant] = constant;
-    return acc;
-  }, {});
-}
-
 export function createReducer(initialState, reducerMap) {
   return (state = initialState, action) => {
     const reducer = reducerMap[action.type];


### PR DESCRIPTION
## Changes
- Conform to the ducks-modular-redux standard
  - https://github.com/erikras/ducks-modular-redux
## Why?
- Avoid polluting the global namespace for action types
- Also ducks
